### PR TITLE
[CLS-1389] Removed utf8_bin annotation in TranslationToken entity

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -11,6 +11,7 @@
 * [MPFE-1050][ModeraSecurityBundle] Add validators for username and email
 * [MPFE-1049][ModeraSecurityBundle] Clean non-letter characters from First & Last name, except "space" and "-"
 * [CLS-1236][ModeraFileRepositoryBundle] Update version for gaufrette library
+* [MPFE-984][ModeraTranslationsBundle] Collation utf8_bin is now not necessary for TranslationToken's entity
 
 ## 2.56.0 (05.10.2017)
 

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,5 +1,9 @@
 # UPGRADE GUIDE, 2.x
 
+## 2.57.0 (not released yet, in development)
+
+* [MPFE-984] Collation utf8_bin is now not necessary for TranslationToken's entity, so you may set another one via running query in your MySQL database. For example: `ALTER TABLE modera_translations_translationtoken CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;`.
+
 ## 2.56.0 (05.10.2017)
 
 * [MPFE-1014] Semantic configuration properties `modera_backend_security/mail_service` and `modera_security/password_strength/mailer`

--- a/src/Modera/TranslationsBundle/Entity/TranslationToken.php
+++ b/src/Modera/TranslationsBundle/Entity/TranslationToken.php
@@ -7,11 +7,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Modera\LanguagesBundle\Entity\Language;
 
 /**
- * If you change a table name then don't forget to update
- * \Modera\ModuleBundle\Composer\ScriptHandler::updateTranslationsTableCollation.
- *
  * @ORM\Entity
- * @ORM\Table(name="modera_translations_translationtoken", options={"collate"="utf8_bin"})
+ * @ORM\Table(name="modera_translations_translationtoken")
  *
  * @author    Sergei Vizel <sergei.vizel@modera.org>
  * @copyright 2014 Modera Foundation


### PR DESCRIPTION
Now using utf8_bin collation is not necessary with new translations import.