### PR TITLE
[MPFE-1068] ModeraServerCrudBundle: proper pagination fetch for complex queries

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -12,6 +12,7 @@
 * [MPFE-1049][ModeraSecurityBundle] Clean non-letter characters from First & Last name, except "space" and "-"
 * [CLS-1236][ModeraFileRepositoryBundle] Update version for gaufrette library
 * [MPFE-984][ModeraTranslationsBundle] Collation utf8_bin is now not necessary for TranslationToken's entity
+* [MPFE-1068][ModeraServerCrudBundle] Proper pagination fetch for complex queries
 
 ## 2.56.0 (05.10.2017)
 

--- a/src/Modera/ServerCrudBundle/Tests/Fixtures/Entity/entities.php
+++ b/src/Modera/ServerCrudBundle/Tests/Fixtures/Entity/entities.php
@@ -3,6 +3,7 @@
 namespace Modera\ServerCrudBundle\Tests\Functional;
 
 use Doctrine\ORM\Mapping as Orm;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @Orm\Entity
@@ -27,6 +28,17 @@ class DummyUser
     public $lastname;
 
     /**
+     * @var ArrayCollection
+     * @Orm\OneToMany(targetEntity="DummyNote", mappedBy="user")
+     */
+    public $notes;
+
+    public function __construct()
+    {
+        $this->notes = new ArrayCollection();
+    }
+
+    /**
      * @param mixed $id
      */
     public function setId($id)
@@ -47,6 +59,67 @@ class DummyUser
     public function setLastname($lastname)
     {
         $this->lastname = $lastname;
+    }
+
+    public function addNote(DummyNote $note)
+    {
+        if (!$this->notes->contains($note)) {
+            $note->setUser($this);
+            $this->notes[] = $note;
+        }
+    }
+
+    public static function clazz()
+    {
+        return get_called_class();
+    }
+}
+
+/**
+ * @Orm\Entity
+ */
+class DummyNote
+{
+    /**
+     * @Orm\Column(type="integer")
+     * @Orm\Id
+     * @Orm\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Orm\Column(type="string")
+     */
+    public $text;
+
+    /**
+     * @var DummyUser
+     * @Orm\ManyToOne(targetEntity="DummyUser", inversedBy="notes")
+     * @Orm\JoinColumn(name="user_id", referencedColumnName="id")
+     */
+    private $user;
+
+    /**
+     * @param mixed $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function setUser(DummyUser $user)
+    {
+        $this->user = $user;
     }
 
     public static function clazz()


### PR DESCRIPTION
**For tests:**
```js
Actions.ModeraBackendTranslationsTool_Translations.list({
    page: 1,
    start: 0,
    limit: 25,
    hydration: { profile: "list" },
    filter: [
        [
            { property: "domain", value: "eq:user" },
            { property: "tokenName", value: "like:%user%" }, 
            { property: "languageTranslationTokens.translation", value: "like:%user%" }
        ]
    ]
}, ({items, total}) => console.log({ items: items.length, total }));
```

**Before fix:**
```js
{ items: 9, total: "61" }
```

**After fix:**
```js
{ items: 25, total: 61 }
```