### PR TITLE
[CLS-2151] removing count() use on non countable objects.

### DIFF
--- a/src/Modera/TranslationsBundle/Command/CompileTranslationsCommand.php
+++ b/src/Modera/TranslationsBundle/Command/CompileTranslationsCommand.php
@@ -103,7 +103,7 @@ class CompileTranslationsCommand extends ContainerAwareCommand
             }
 
             foreach ($catalogues as $locale => $catalogue) {
-                if ($catalogue instanceof \Countable) {
+                if (!count($catalogue->all())) {
                     continue;
                 }
 

--- a/src/Modera/TranslationsBundle/Command/CompileTranslationsCommand.php
+++ b/src/Modera/TranslationsBundle/Command/CompileTranslationsCommand.php
@@ -103,7 +103,7 @@ class CompileTranslationsCommand extends ContainerAwareCommand
             }
 
             foreach ($catalogues as $locale => $catalogue) {
-                if (!count($catalogue)) {
+                if ($catalogue instanceof \Countable) {
                     continue;
                 }
 


### PR DESCRIPTION
from php 7.2 using count on non countable objects raise warning.