### PR TITLE
[CLS-3218] Translations import during update/installation

### DIFF
--- a/src/Modera/BackendTranslationsToolBundle/Handling/ExtjsTranslationHandler.php
+++ b/src/Modera/BackendTranslationsToolBundle/Handling/ExtjsTranslationHandler.php
@@ -2,14 +2,14 @@
 
 namespace Modera\BackendTranslationsToolBundle\Handling;
 
-use Modera\TranslationsBundle\Handling\TemplateTranslationHandler;
+use Modera\TranslationsBundle\Handling\BundleTranslationHandler;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
  * @author    Sergei Vizel <sergei.vizel@modera.org>
  * @copyright 2014 Modera Foundation
  */
-class ExtjsTranslationHandler extends TemplateTranslationHandler
+class ExtjsTranslationHandler extends BundleTranslationHandler
 {
     const SOURCE_NAME = 'extjs';
 

--- a/src/Modera/TranslationsBundle/Catalogue/FasterAbstractOperation.php
+++ b/src/Modera/TranslationsBundle/Catalogue/FasterAbstractOperation.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Modera\TranslationsBundle\Catalogue;
+
+use Symfony\Component\Translation\Catalogue\AbstractOperation;
+use Symfony\Component\Translation\Exception\LogicException;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Base catalogues binary operation class.
+ *
+ * A catalogue binary operation performs operation on
+ * source (the left argument) and target (the right argument) catalogues.
+ *
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+abstract class FasterAbstractOperation extends AbstractOperation
+{
+    /**
+     * @throws LogicException
+     */
+    public function __construct(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    {
+        parent::__construct($source, $target);
+
+        $this->result = new FasterMessageCatalogue($source->getLocale());
+    }
+
+}

--- a/src/Modera/TranslationsBundle/Catalogue/FasterMessageCatalogue.php
+++ b/src/Modera/TranslationsBundle/Catalogue/FasterMessageCatalogue.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Modera\TranslationsBundle\Catalogue;
+
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Translation\Exception\LogicException;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\MetadataAwareInterface;
+
+/**
+ * Class FasterMessageCatalogue. This is almost identical copy of Symfony's
+ * {@link \Symfony\Component\Translation\MessageCatalogue} with one exception. Set method doesn't
+ * rely on {@link MessageCatalogue::add} which internaly uses {@link array_replace} which is slow if you want
+ * to set only one translation. Instead of it it sets translation directly. It is also impossible to use inheritance
+ * because Symfony's class has all it's members as private.
+ * 
+ * @package Modera\TranslationsBundle\Catalogue
+ */
+class FasterMessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterface
+{
+    private $messages = [];
+    private $metadata = [];
+    private $resources = [];
+    private $locale;
+    private $fallbackCatalogue;
+    private $parent;
+
+    /**
+     * @param string $locale   The locale
+     * @param array  $messages An array of messages classified by domain
+     */
+    public function __construct($locale, array $messages = [])
+    {
+        $this->locale = $locale;
+        $this->messages = $messages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDomains()
+    {
+        return array_keys($this->messages);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all($domain = null)
+    {
+        if (null === $domain) {
+            return $this->messages;
+        }
+
+        return isset($this->messages[$domain]) ? $this->messages[$domain] : [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($id, $translation, $domain = 'messages')
+    {
+        if (!isset($this->messages[$domain])) {
+            $this->messages[$domain] = [];
+        }
+
+        $this->messages[$domain][$id] = $translation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id, $domain = 'messages')
+    {
+        if (isset($this->messages[$domain][$id])) {
+            return true;
+        }
+
+        if (null !== $this->fallbackCatalogue) {
+            return $this->fallbackCatalogue->has($id, $domain);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function defines($id, $domain = 'messages')
+    {
+        return isset($this->messages[$domain][$id]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id, $domain = 'messages')
+    {
+        if (isset($this->messages[$domain][$id])) {
+            return $this->messages[$domain][$id];
+        }
+
+        if (null !== $this->fallbackCatalogue) {
+            return $this->fallbackCatalogue->get($id, $domain);
+        }
+
+        return $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replace($messages, $domain = 'messages')
+    {
+        $this->messages[$domain] = [];
+
+        $this->add($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($messages, $domain = 'messages')
+    {
+        if (!isset($this->messages[$domain])) {
+            $this->messages[$domain] = $messages;
+        } else {
+            $this->messages[$domain] = array_replace($this->messages[$domain], $messages);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCatalogue(MessageCatalogueInterface $catalogue)
+    {
+        if ($catalogue->getLocale() !== $this->locale) {
+            throw new LogicException(sprintf('Cannot add a catalogue for locale "%s" as the current locale for this catalogue is "%s"', $catalogue->getLocale(), $this->locale));
+        }
+
+        foreach ($catalogue->all() as $domain => $messages) {
+            $this->add($messages, $domain);
+        }
+
+        foreach ($catalogue->getResources() as $resource) {
+            $this->addResource($resource);
+        }
+
+        if ($catalogue instanceof MetadataAwareInterface) {
+            $metadata = $catalogue->getMetadata('', '');
+            $this->addMetadata($metadata);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFallbackCatalogue(MessageCatalogueInterface $catalogue)
+    {
+        // detect circular references
+        $c = $catalogue;
+        while ($c = $c->getFallbackCatalogue()) {
+            if ($c->getLocale() === $this->getLocale()) {
+                throw new LogicException(sprintf('Circular reference detected when adding a fallback catalogue for locale "%s".', $catalogue->getLocale()));
+            }
+        }
+
+        $c = $this;
+        do {
+            if ($c->getLocale() === $catalogue->getLocale()) {
+                throw new LogicException(sprintf('Circular reference detected when adding a fallback catalogue for locale "%s".', $catalogue->getLocale()));
+            }
+
+            foreach ($catalogue->getResources() as $resource) {
+                $c->addResource($resource);
+            }
+        } while ($c = $c->parent);
+
+        $catalogue->parent = $this;
+        $this->fallbackCatalogue = $catalogue;
+
+        foreach ($catalogue->getResources() as $resource) {
+            $this->addResource($resource);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFallbackCatalogue()
+    {
+        return $this->fallbackCatalogue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResources()
+    {
+        return array_values($this->resources);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addResource(ResourceInterface $resource)
+    {
+        $this->resources[$resource->__toString()] = $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($key = '', $domain = 'messages')
+    {
+        if ('' == $domain) {
+            return $this->metadata;
+        }
+
+        if (isset($this->metadata[$domain])) {
+            if ('' == $key) {
+                return $this->metadata[$domain];
+            }
+
+            if (isset($this->metadata[$domain][$key])) {
+                return $this->metadata[$domain][$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMetadata($key, $value, $domain = 'messages')
+    {
+        $this->metadata[$domain][$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMetadata($key = '', $domain = 'messages')
+    {
+        if ('' == $domain) {
+            $this->metadata = [];
+        } elseif ('' == $key) {
+            unset($this->metadata[$domain]);
+        } else {
+            unset($this->metadata[$domain][$key]);
+        }
+    }
+
+    /**
+     * Adds current values with the new values.
+     *
+     * @param array $values Values to add
+     */
+    private function addMetadata(array $values)
+    {
+        foreach ($values as $domain => $keys) {
+            foreach ($keys as $key => $value) {
+                $this->setMetadata($key, $value, $domain);
+            }
+        }
+    }
+}

--- a/src/Modera/TranslationsBundle/Catalogue/MergeOperation.php
+++ b/src/Modera/TranslationsBundle/Catalogue/MergeOperation.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Modera\TranslationsBundle\Catalogue;
+
+/**
+ * Merge operation between two catalogues as follows:
+ * all = source ∪ target = {x: x ∈ source ∨ x ∈ target}
+ * new = all ∖ source = {x: x ∈ target ∧ x ∉ source}
+ * obsolete = source ∖ all = {x: x ∈ source ∧ x ∉ source ∧ x ∉ target} = ∅
+ * Basically, the result contains messages from both catalogues.
+ *
+ * This is almost identical copy of Symfony's {@link \Symfony\Component\Translation\Catalogue\MergeOperation}
+ * with the exception that it uses {@link \Symfony\Component\Translation\MessageCatalogueInterface\MessageCatalogueInterface::set}
+ * instead of {@link \Symfony\Component\Translation\MessageCatalogueInterface\MessageCatalogueInterface::add} to combine
+ * messages into new catalogue
+ * 
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class MergeOperation extends FasterAbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function processDomain($domain)
+    {
+        $this->messages[$domain] = [
+            'all' => [],
+            'new' => [],
+            'obsolete' => [],
+        ];
+
+        foreach ($this->source->all($domain) as $id => $message) {
+            $this->messages[$domain]['all'][$id] = $message;
+            $this->result->set($id, $message, $domain);
+            if (null !== $keyMetadata = $this->source->getMetadata($id, $domain)) {
+                $this->result->setMetadata($id, $keyMetadata, $domain);
+            }
+        }
+
+        foreach ($this->target->all($domain) as $id => $message) {
+            if (!$this->source->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->messages[$domain]['new'][$id] = $message;
+                $this->result->set($id, $message, $domain);
+                if (null !== $keyMetadata = $this->target->getMetadata($id, $domain)) {
+                    $this->result->setMetadata($id, $keyMetadata, $domain);
+                }
+            }
+        }
+    }
+}

--- a/src/Modera/TranslationsBundle/Catalogue/TargetOperation.php
+++ b/src/Modera/TranslationsBundle/Catalogue/TargetOperation.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Modera\TranslationsBundle\Catalogue;
+
+/**
+ * Target operation between two catalogues:
+ * intersection = source ∩ target = {x: x ∈ source ∧ x ∈ target}
+ * all = intersection ∪ (target ∖ intersection) = target
+ * new = all ∖ source = {x: x ∈ target ∧ x ∉ source}
+ * obsolete = source ∖ all = source ∖ target = {x: x ∈ source ∧ x ∉ target}
+ * Basically, the result contains messages from the target catalogue.
+ *
+ * This is almost identical copy of Symfony's {@link \Symfony\Component\Translation\Catalogue\MergeOperation}
+ * with the exception that it uses {@link \Symfony\Component\Translation\MessageCatalogueInterface\MessageCatalogueInterface::set}
+ * instead of {@link \Symfony\Component\Translation\MessageCatalogueInterface\MessageCatalogueInterface::add} to combine
+ * messages into new catalogue
+ *
+ * @author Michael Lee <michael.lee@zerustech.com>
+ */
+class TargetOperation extends FasterAbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function processDomain($domain)
+    {
+        $this->messages[$domain] = [
+            'all' => [],
+            'new' => [],
+            'obsolete' => [],
+        ];
+
+        // For 'all' messages, the code can't be simplified as ``$this->messages[$domain]['all'] = $target->all($domain);``,
+        // because doing so will drop messages like {x: x ∈ source ∧ x ∉ target.all ∧ x ∈ target.fallback}
+        //
+        // For 'new' messages, the code can't be simplified as ``array_diff_assoc($this->target->all($domain), $this->source->all($domain));``
+        // because doing so will not exclude messages like {x: x ∈ target ∧ x ∉ source.all ∧ x ∈ source.fallback}
+        //
+        // For 'obsolete' messages, the code can't be simplified as ``array_diff_assoc($this->source->all($domain), $this->target->all($domain))``
+        // because doing so will not exclude messages like {x: x ∈ source ∧ x ∉ target.all ∧ x ∈ target.fallback}
+
+        foreach ($this->source->all($domain) as $id => $message) {
+            if ($this->target->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->result->set($id, $message, $domain);
+                if (null !== $keyMetadata = $this->source->getMetadata($id, $domain)) {
+                    $this->result->setMetadata($id, $keyMetadata, $domain);
+                }
+            } else {
+                $this->messages[$domain]['obsolete'][$id] = $message;
+            }
+        }
+
+        foreach ($this->target->all($domain) as $id => $message) {
+            if (!$this->source->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->messages[$domain]['new'][$id] = $message;
+                $this->result->set($id, $message, $domain);
+                if (null !== $keyMetadata = $this->target->getMetadata($id, $domain)) {
+                    $this->result->setMetadata($id, $keyMetadata, $domain);
+                }
+            }
+        }
+    }
+}

--- a/src/Modera/TranslationsBundle/Command/ImportTranslationsCommand.php
+++ b/src/Modera/TranslationsBundle/Command/ImportTranslationsCommand.php
@@ -3,11 +3,11 @@
 namespace Modera\TranslationsBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Translation\MessageCatalogue;
+use Modera\TranslationsBundle\Catalogue\FasterMessageCatalogue;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Translation\Catalogue\MergeOperation;
-use Symfony\Component\Translation\Catalogue\TargetOperation;
+use Modera\TranslationsBundle\Catalogue\MergeOperation;
+use Modera\TranslationsBundle\Catalogue\TargetOperation;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Modera\TranslationsBundle\EventListener\LanguageTranslationTokenListener;
 use Modera\TranslationsBundle\Handling\TranslationHandlerInterface;
@@ -76,7 +76,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         foreach ($languages as $language) {
             $locale = $language->getLocale();
 
-            $extractedCatalogues = new MessageCatalogue($locale);
+            $extractedCatalogues = new FasterMessageCatalogue($locale);
             foreach ($handlers as $handler) {
                 $bundleName = $handler->getBundleName();
 
@@ -94,7 +94,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
                 }
             }
 
-            $databaseCatalogue = new MessageCatalogue($locale);
+            $databaseCatalogue = new FasterMessageCatalogue($locale);
             foreach ($tokens as $domain => $arr) {
                 foreach ($arr as $token) {
                     if ($token['isObsolete']) {
@@ -336,7 +336,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         foreach ($tokens as $domain => $arr) {
             foreach ($arr as $token) {
                 $translations = $this->getTokenTranslations($token, $languages, $listener);
-                if ($translations != $token['translations']) {
+                if (json_encode($translations, JSON_UNESCAPED_UNICODE) != $token['translations']) {
                     $tokenTranslations[] = array(
                         'id' => $token['id'],
                         'translations' => $translations,

--- a/src/Modera/TranslationsBundle/Handling/BundleTranslationHandler.php
+++ b/src/Modera/TranslationsBundle/Handling/BundleTranslationHandler.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Modera\TranslationsBundle\Handling;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\Extractor\ExtractorInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Reader\TranslationReader;
+
+abstract class BundleTranslationHandler implements TranslationHandlerInterface
+{
+    const SOURCE_NAME = 'bundle';
+
+    static $extractedCatalogues;
+
+    /**
+     * @var string
+     */
+    protected $bundle;
+
+    /**
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    /**
+     * @var ExtractorInterface
+     */
+    protected $extractor;
+
+    /**
+     * @var TranslationReader
+     */
+    protected $loader;
+
+    /**
+     * @param KernelInterface $kernel
+     * @param TranslationReader $loader
+     * @param ExtractorInterface $extractor
+     * @param string $bundle
+     */
+    public function __construct(
+        KernelInterface $kernel,
+        TranslationReader $loader,
+        ExtractorInterface $extractor,
+        $bundle
+    )
+    {
+        $this->kernel = $kernel;
+        $this->loader = $loader;
+        $this->extractor = $extractor;
+        $this->bundle = $bundle;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBundleName()
+    {
+        return $this->bundle;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSources()
+    {
+        return array(static::SOURCE_NAME);
+    }
+
+    /**
+     * @param string $source
+     * @param string $locale
+     *
+     * @return MessageCatalogueInterface | null
+     */
+    public function extract($source, $locale)
+    {
+        if (!$this->isSourceAvailable($source)) {
+            return;
+        }
+
+        $fs = new Filesystem();
+
+        /* @var Bundle $foundBundle */
+        $foundBundle = $this->kernel->getBundle($this->bundle);
+        $resourcesDir = $this->resolveResourcesDirectory($foundBundle);
+
+        $cacheKey = $this->bundle . '||' . static::SOURCE_NAME;
+
+        if ($this instanceof LocaleDependentTranslationHandlerInterface
+            || (!($this instanceof LocaleDependentTranslationHandlerInterface) && !isset(static::$extractedCatalogues[$cacheKey]))) {
+
+            // load any messages from templates
+            $extractedCatalogue = new MessageCatalogue($locale);
+            if ($fs->exists($resourcesDir)) {
+                $this->extractor->extract($resourcesDir, $extractedCatalogue);
+            }
+
+            if (!$this instanceof LocaleDependentTranslationHandlerInterface) {
+                static::$extractedCatalogues[$cacheKey] = $extractedCatalogue->all();
+            }
+        } else {
+            $extractedCatalogue = new MessageCatalogue($locale, static::$extractedCatalogues[$cacheKey]);
+        }
+
+        return $extractedCatalogue;
+    }
+
+    /**
+     * @param $source
+     *
+     * @return bool
+     */
+    protected function isSourceAvailable($source)
+    {
+        return static::SOURCE_NAME == $source;
+    }
+
+    /**
+     * @param Bundle $bundle
+     *
+     * @return string
+     */
+    abstract protected function resolveResourcesDirectory(BundleInterface $bundle);
+}

--- a/src/Modera/TranslationsBundle/Handling/LocaleDependentTranslationHandlerInterface.php
+++ b/src/Modera/TranslationsBundle/Handling/LocaleDependentTranslationHandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Modera\TranslationsBundle\Handling;
+
+
+interface LocaleDependentTranslationHandlerInterface
+{
+
+}

--- a/src/Modera/TranslationsBundle/Handling/PhpClassesTranslationHandler.php
+++ b/src/Modera/TranslationsBundle/Handling/PhpClassesTranslationHandler.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  * @author Sergei Lissovski <sergei.lissovski@modera.org>
  * @copyright 2014 Modera Foundation
  */
-class PhpClassesTranslationHandler extends TemplateTranslationHandler
+class PhpClassesTranslationHandler extends BundleTranslationHandler
 {
     const SOURCE_NAME = 'php-classes';
 

--- a/src/Modera/TranslationsBundle/Handling/ResourcesFileTranslationHandler.php
+++ b/src/Modera/TranslationsBundle/Handling/ResourcesFileTranslationHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modera\TranslationsBundle\Handling;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ResourcesFileTranslationHandler extends BundleTranslationHandler implements LocaleDependentTranslationHandlerInterface
+{
+    const SOURCE_NAME = 'resource';
+
+    /**
+     * @inheritDoc
+     */
+    public function extract($source, $locale)
+    {
+        if (!$this->isSourceAvailable($source)) {
+            return;
+        }
+
+        $fs = new Filesystem();
+
+        /* @var Bundle $foundBundle */
+        $foundBundle = $this->kernel->getBundle($this->bundle);
+
+        // load any messages from templates
+        $extractedCatalogue = new MessageCatalogue($locale);
+        $translationsDir = $this->resolveResourcesDirectory($foundBundle);
+
+        // load any existing messages from the translation files
+        if ($fs->exists($translationsDir)) {
+            $currentCatalogue = new MessageCatalogue($locale);
+            $this->loader->read($translationsDir, $currentCatalogue);
+            // load fallback translations
+            $parts = explode('_', $locale);
+            if (count($parts) > 1) {
+                $fallbackCatalogue = new MessageCatalogue($parts[0]);
+                $this->loader->read($translationsDir, $fallbackCatalogue);
+
+                $mergeOperation = new MergeOperation(
+                    $currentCatalogue,
+                    new MessageCatalogue($locale, $fallbackCatalogue->all())
+                );
+                $currentCatalogue = $mergeOperation->getResult();
+            }
+
+            foreach ($currentCatalogue->getDomains() as $domain) {
+                $messages = $currentCatalogue->all($domain);
+                if (count($messages)) {
+                    $extractedCatalogue->add($messages, $domain);
+                }
+            }
+        }
+
+        return $extractedCatalogue;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function resolveResourcesDirectory(BundleInterface $bundle)
+    {
+        return $bundle->getPath() . '/Resources/translations/';
+    }
+
+}

--- a/src/Modera/TranslationsBundle/Handling/TemplateTranslationHandler.php
+++ b/src/Modera/TranslationsBundle/Handling/TemplateTranslationHandler.php
@@ -2,7 +2,6 @@
 
 namespace Modera\TranslationsBundle\Handling;
 
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -16,136 +15,15 @@ use Symfony\Component\Translation\Extractor\ExtractorInterface;
  * @author    Sergei Vizel <sergei.vizel@modera.org>
  * @copyright 2014 Modera Foundation
  */
-class TemplateTranslationHandler implements TranslationHandlerInterface
+class TemplateTranslationHandler extends BundleTranslationHandler
 {
     const SOURCE_NAME = 'template';
 
     /**
-     * @var string
-     */
-    private $bundle;
-
-    /**
-     * @var KernelInterface
-     */
-    private $kernel;
-
-    /**
-     * @var ExtractorInterface
-     */
-    private $extractor;
-
-    /**
-     * @var TranslationReader
-     */
-    private $loader;
-
-    /**
-     * @param KernelInterface $kernel
-     * @param TranslationReader $loader
-     * @param ExtractorInterface $extractor
-     * @param string $bundle
-     */
-    public function __construct(
-        KernelInterface $kernel,
-        TranslationReader $loader,
-        ExtractorInterface $extractor,
-        $bundle
-    )
-    {
-        $this->kernel = $kernel;
-        $this->loader = $loader;
-        $this->extractor = $extractor;
-        $this->bundle = $bundle;
-    }
-
-    /**
-     * @return string
-     */
-    public function getBundleName()
-    {
-        return $this->bundle;
-    }
-
-    /**
-     * @return array
-     */
-    public function getSources()
-    {
-        return array(static::SOURCE_NAME);
-    }
-
-    /**
-     * @param string $source
-     * @param string $locale
-     *
-     * @return MessageCatalogueInterface | null
-     */
-    public function extract($source, $locale)
-    {
-        if (!$this->isSourceAvailable($source)) {
-            return;
-        }
-
-        $fs = new Filesystem();
-
-        /* @var Bundle $foundBundle */
-        $foundBundle = $this->kernel->getBundle($this->bundle);
-
-        // load any messages from templates
-        $extractedCatalogue = new MessageCatalogue($locale);
-        $resourcesDir = $this->resolveResourcesDirectory($foundBundle);
-        if ($fs->exists($resourcesDir)) {
-            $this->extractor->extract($resourcesDir, $extractedCatalogue);
-        }
-
-        // load any existing messages from the translation files
-        $translationsDir = $foundBundle->getPath().'/Resources/translations';
-        if ($fs->exists($translationsDir)) {
-            $currentCatalogue = new MessageCatalogue($locale);
-            $this->loader->read($translationsDir, $currentCatalogue);
-
-            // load fallback translations
-            $parts = explode('_', $locale);
-            if (count($parts) > 1) {
-                $fallbackCatalogue = new MessageCatalogue($parts[0]);
-                $this->loader->read($translationsDir, $fallbackCatalogue);
-
-                $mergeOperation = new MergeOperation(
-                    $currentCatalogue,
-                    new MessageCatalogue($locale, $fallbackCatalogue->all())
-                );
-                $currentCatalogue = $mergeOperation->getResult();
-            }
-
-            foreach ($extractedCatalogue->getDomains() as $domain) {
-                $messages = $currentCatalogue->all($domain);
-                if (count($messages)) {
-                    $extractedCatalogue->add($messages, $domain);
-                }
-            }
-        }
-
-        return $extractedCatalogue;
-    }
-
-    /**
-     * @param $source
-     *
-     * @return bool
-     */
-    protected function isSourceAvailable($source)
-    {
-        return static::SOURCE_NAME == $source;
-    }
-
-    /**
-     * @param Bundle $bundle
-     *
-     * @return string
+     * @inheritDoc
      */
     protected function resolveResourcesDirectory(BundleInterface $bundle)
     {
-        return $bundle->getPath().'/Resources/views/';
+        return $bundle->getPath() . '/Resources/views/';
     }
 }

--- a/src/Modera/TranslationsBundle/Resources/config/services.xml
+++ b/src/Modera/TranslationsBundle/Resources/config/services.xml
@@ -67,6 +67,16 @@
             <argument type="service" id="modera_translations.translation.extractor" />
         </service>
 
+        <service id="modera_translations.handling.resources_file_translation_handler"
+                 class="Modera\TranslationsBundle\Handling\ResourcesFileTranslationHandler"
+                 abstract="true"
+                 public="false">
+
+            <argument type="service" id="kernel" />
+            <argument type="service" id="modera_translations.translation.reader" />
+            <argument type="service" id="modera_translations.translation.extractor" />
+        </service>
+
         <service id="modera_translations.compiler.translations_compiler"
                  class="Modera\TranslationsBundle\Compiler\TranslationsCompiler"
                  public="true">

--- a/src/Modera/TranslationsBundle/Tests/Fixtures/SecondBundle/Resources/config/services.xml
+++ b/src/Modera/TranslationsBundle/Tests/Fixtures/SecondBundle/Resources/config/services.xml
@@ -22,5 +22,13 @@
             <tag name="modera_translations.translation_handler" />
         </service>
 
+        <service id="modera_translations_second_dummy.handling.resources_file_translation_handler"
+                 parent="modera_translations.handling.resources_file_translation_handler">
+
+            <argument>ModeraTranslationsSecondDummyBundle</argument>
+
+            <tag name="modera_translations.translation_handler" />
+        </service>
+
     </services>
 </container>

--- a/src/Modera/TranslationsBundle/Tests/Fixtures/SecondBundle/Resources/translations/messages.en.yml
+++ b/src/Modera/TranslationsBundle/Tests/Fixtures/SecondBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,1 @@
+'This token in yml file': 'This token in yml file'

--- a/src/Modera/TranslationsBundle/Tests/Functional/Command/CompileTranslationsCommandTest.php
+++ b/src/Modera/TranslationsBundle/Tests/Functional/Command/CompileTranslationsCommandTest.php
@@ -35,7 +35,7 @@ class CompileTranslationsCommandTest extends ImportTranslationsCommandTest
         $loader->read(dirname($transPath), $catalogue);
         $messages = $catalogue->all('messages');
 
-        $this->assertEquals(3, count($messages));
+        $this->assertEquals(4, count($messages));
         $this->assertTrue(isset($messages['Test token']));
         $this->assertEquals('Test token', $messages['Test token']);
 
@@ -44,6 +44,9 @@ class CompileTranslationsCommandTest extends ImportTranslationsCommandTest
 
         $this->assertTrue(isset($messages['This token is only in SecondDummy bundle']));
         $this->assertEquals('This token is only in SecondDummy bundle', $messages['This token is only in SecondDummy bundle']);
+
+        $this->assertTrue(isset($messages['This token in yml file']));
+        $this->assertEquals('This token in yml file', $messages['This token in yml file']);
 
         if ($fs->exists($transPath)) {
             foreach (Finder::create()->files()->in($transPath) as $file) {

--- a/src/Modera/TranslationsBundle/Tests/Functional/Command/ImportTranslationsCommandTest.php
+++ b/src/Modera/TranslationsBundle/Tests/Functional/Command/ImportTranslationsCommandTest.php
@@ -59,7 +59,7 @@ class ImportTranslationsCommandTest extends AbstractFunctionalTestCase
         $this->launchImportCommand();
 
         $tokens = self::$em->getRepository(TranslationToken::clazz())->findAll();
-        $this->assertEquals(3, count($tokens));
+        $this->assertEquals(4, count($tokens));
 
         $tokens = self::$em->getRepository(TranslationToken::clazz())->findBy(array(
             'tokenName' => 'Test token'
@@ -76,6 +76,11 @@ class ImportTranslationsCommandTest extends AbstractFunctionalTestCase
             'tokenName' => 'This token is only in SecondDummy bundle'
         ));
         $this->assertToken($token, 'This token is only in SecondDummy bundle');
+
+        $token = self::$em->getRepository(TranslationToken::clazz())->findOneBy(array(
+            'tokenName' => 'This token in yml file'
+        ));
+        $this->assertToken($token, 'This token in yml file');
 
         $token = self::$em->getRepository(TranslationToken::clazz())->findOneBy(array(
             'tokenName' => 'undefined',


### PR DESCRIPTION
Things that were changes/fixed:
- Fixed wrong token compare condition which resulted in several thousand update requests to DB with data that wasn't really changed
- Resource file import was executed for each translation handler which created slight overhead.
- Introduces LocaleDependentTranslationHandlerInterface which marks handler as locale dependent.. Usually translation handlers do not need to be executed for each locale and small optimization is possible for handlers that do not depend on locale.
- Class structure slightly cleaned up.
Before:
![TemplateTranslationHandlerBefore](https://user-images.githubusercontent.com/2372366/71511435-0197f800-289b-11ea-992c-1458958310da.png)
After:
![TemplateTranslationHandlerAfter](https://user-images.githubusercontent.com/2372366/71511446-0bb9f680-289b-11ea-924f-a5e92e713ab8.png)
- Most optimisation comes from patching core Symony classes from Translation bundle, which used array_replace function for updating single translations. Changing that to direct array assignment resulted in six times higher speed of translation processing.